### PR TITLE
Keep reference to `this`

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function addWith(obj, src, exclude) {
 
   src = '(function (' + vars.join(', ') + ') {' +
     src +
-    '}(' + inputVars.join(',') + '))'
+    '}.bind(this)(' + inputVars.join(',') + '))'
 
   return ';' + declareLocal + ';' + unwrapReturns(src, result) + ';'
 }
@@ -77,12 +77,17 @@ function unwrapReturns(src, result) {
   var originalSource = src
   var hasReturn = false
   var ast = uglify.parse(src)
+  var ref
   src = src.split('')
 
-  if (ast.body.length !== 1 || ast.body[0].TYPE !== 'SimpleStatement' ||
-      ast.body[0].body.TYPE !== 'Call' || ast.body[0].body.expression.TYPE !== 'Function')
+  if ((ref = ast.body).length !== 1
+   || (ref = ref[0]).TYPE !== 'SimpleStatement'
+   || (ref = ref.body).TYPE !== 'Call'
+   || (ref = ref.expression).TYPE !== 'Call'
+   || (ref = ref.expression).TYPE !== 'Dot' || ref.property !== 'bind'
+   || (ref = ref.expression).TYPE !== 'Function')
     throw new Error('AST does not seem to represent a self-calling function')
-  var fn = ast.body[0].body.expression
+  var fn = ref
 
   var walker = new uglify.TreeWalker(visitor)
   function visitor(node, descend) {

--- a/test/index.js
+++ b/test/index.js
@@ -127,3 +127,17 @@ describe('addWith("obj || {}", "return foo")', function () {
     done()
   })
 })
+
+describe('addWith("obj || {}", "return this[foo]")', function () {
+  it('keeps reference to this', function (done) {
+    var src = addWith('obj || {}', 'return this[foo]')
+    // obj.bar = obj.foo
+    var obj = {
+        foo: 'bar',
+        bar: 'ding',
+        fn: Function('obj', src)
+      }
+    assert(obj.fn(obj) === 'ding')
+    done()
+  })
+})


### PR DESCRIPTION
Hi. I'm working on semi-conservative refactoring of mixins in jade (all existing unit tests are passed, only private api slightly changed) to make them first class objects, as well as proper handling of `this` refernece in templates. In classical jade `this` reference is used for passing of {block,attributes} to the mixin like 

``` javascript
    var buf, jade // runtime vars enclosed into template's closure 
    mixin.call({block,attributes}, args...)
```

I've refactored lexer/parser/compiler + with
 to make mixins essentialy a curried functions while decoupling them from jade-runtime and buf:

``` javascript
      mixin(args...)(attributes,block)(buf, jade)
```

so now mixins can be compiled separately with `jade.compileMethod(src, options)` and passed as parameters for templates, or attached to function prototype to make templates as methods, or simply bound by `mixin.bind(someobj)`

also i've added first-class mixin call syntax

``` jade
       +[expression_that_evaluates_to_mixin]#id.class(data-test=123)(arg1,agr2,arg3)
             span I'm in block
       +[jade_mixins["test"]](1,2,3)
       +test(1,2,3)
       +[obj.renderView] //- this was a primary goal
```

All this features are based on small enhancement of `with` module to make it respectful for `this` reference.
My semantics/syntax for mixins is arguable but I hope that at least this change in `with` matters and can be merged.

Regards, Anatoly
P.S. my fork of jade is here https://github.com/Artazor/jade - it would be great to hear any comments about that direction
