### PR TITLE
Expose parse error location information

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ This is not the case if foo is in `exclude`.  If a variable is excluded, we igno
 
 It is also safe to use in strict mode (unlike `with`) and it minifies properly (`with` disables virtually all minification).
 
+#### Parsing Errors
+
+with internally uses babylon to parse code passed to `addWith`.  If babylon throws an error, probably due to a syntax error, `addWith` returns an error wrapping the babylon error, so you can
+retrieve location information.  `error.component` is `"src"` if the error is in the body or `"obj"` if it's in the object part of the with expression.  `error.babylonError` is
+the error thrown from babylon.
+
 ## License
 
   MIT

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,24 @@ export default function addWith(obj, src, exclude = []) {
   obj = obj + '';
   src = src + '';
 
-  const ast = parse(src, parseOptions);
-  const objAst = parse(obj, parseOptions);
+  let ast;
+  try {
+    ast = parse(src, parseOptions);
+  } catch(e) {
+    throw Object.assign(new Error('Error parsing body of the with expression'), {
+      component: 'src',
+      babylonError: e
+    });
+  }
+  let objAst;
+  try {
+    objAst = parse(obj, parseOptions);
+  } catch(e) {
+    throw Object.assign(new Error('Error parsing object part of the with expression'), {
+      component: 'obj',
+      babylonError: e
+    });
+  }
   exclude = new Set([
     'undefined',
     'this',

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,15 @@ var outputs = []
 
 var sentinel = {}
 var sentinel2 = {}
+
+function tryCatch(block) {
+  try {
+    return {result: 'returned', value: block()}
+  } catch(e) {
+    return {result: 'threw', error: e}
+  }
+}
+
 describe('addWith("obj", "console.log(a)")', function () {
   it('adds the necessary variable declarations', function (done) {
     var src = addWith('obj', 'console.log(a)')
@@ -206,6 +215,31 @@ describe('with reserved words', function () {
       {'yield': sentinel})
   })
 })
+
+describe('with JS syntax error', function () {
+  function spec(obj, body, assertions) {
+    it('exposes error location information', function () {
+      var {result, error} = tryCatch(function () {
+        return addWith(obj, body);
+      })
+      assert(result === 'threw')
+      assertions(error)
+    })
+  }
+  describe('in the obj', function () {
+    spec('syntax error', '1 + 1;', function (error) {
+      assert(error.component === 'obj')
+      assert(error.babylonError.pos === 7)
+    })
+  })
+  describe('in the body', function () {
+    spec('1 + 1', 'syntax error', function (error) {
+      assert(error.component === 'src')
+      assert(error.babylonError.pos === 7)
+    })
+  })
+})
+
 after(function () {
   function beautify(src) {
     try {


### PR DESCRIPTION
Exposes parse errors from Babylon in a way that allows the caller to know exactly where the error occurred.

Allowing the Babylon error to propagate verbatim is not sufficient because it doesn't tell the caller whether the error happened in the `obj` or the `src`.

Prerequisite of pugjs/pug#2830