### PR TITLE
chore: don't publish .tsbuildinfo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 test/
 .travis.yml
+.tsbuildinfo


### PR DESCRIPTION
trivium: the currently published tsbuildinfo is 85kb, or 81.7% of the total package size. i find this impressive, personally :)